### PR TITLE
Fix: OSSCustomSignerCredentialProvider new and init Conflict in nonnull warning in OssModel.h  file

### DIFF
--- a/AliyunOSSSDK/OSSModel.h
+++ b/AliyunOSSSDK/OSSModel.h
@@ -86,8 +86,8 @@ TODOTODO
 @interface OSSCustomSignerCredentialProvider : NSObject <OSSCredentialProvider>
 @property (nonatomic, copy, readonly,) NSString * _Nonnull (^ _Nonnull signContent)( NSString * _Nonnull , NSError * _Nullable *_Nullable);
 
-+ (instancetype _Nullable)new NS_UNAVAILABLE;
-- (instancetype _Nullable)init NS_UNAVAILABLE;
++ (instancetype)new NS_UNAVAILABLE;
+- (instancetype)init NS_UNAVAILABLE;
 
 /**
  * During the task execution, this API is called for signing


### PR DESCRIPTION
Fix: OSSCustomSignerCredentialProvider new and init Conflict in nonnull warning in OssModel.h  file